### PR TITLE
Update Dockerfile OpenJDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk-slim
+FROM openjdk:11-jdk
 EXPOSE 8080
 COPY target/demo-app-1.0-SNAPSHOT.jar app.jar
 ENTRYPOINT ["java", "-jar", "/app.jar"]


### PR DESCRIPTION
docker.io/library/openjdk:11-jdk-slim: not found